### PR TITLE
Ignore __pycache__ that gets created below ./components/shys_m5_tough/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/shys-m5-tough-touchmenu.yaml
+++ b/shys-m5-tough-touchmenu.yaml
@@ -2,14 +2,14 @@ substitutions:
   name: "m5-tough"
   friendly_name: "M5 Tough"
   m5_textsensor_id: "m5_textsensor_id"   # zum reinreichen des shys_m5_tough-Textsensors
-  
+
 esphome:
   name: ${name}
   name_add_mac_suffix: false
   project:
     name: smarthomeyourself.m5_tough
     version: "1.0"
-    
+
   platformio_options:
     board: esp32dev
     framework: arduino
@@ -38,7 +38,7 @@ external_components:
       url: https://github.com/SmartHome-yourself/m5-tough-touchmenu-for-esphome
       ref: main
     components: [shys_m5_tough]
- 
+
 dashboard_import:
   package_import_url: github://SmartHome-yourself/m5-tough-touchmenu-for-esphome/shys-m5-tough-touchmenu.yaml@main
   import_full_config: false


### PR DESCRIPTION
Happens when this component is included as local external component.
    
Ref: https://esphome.io/components/external_components.html#local